### PR TITLE
[BUGFIX] Restrict aim backend module to admins (#17)

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -7,6 +7,7 @@ $parent = (new Typo3Version())->getMajorVersion() >= 14 ? 'admin' : 'tools';
 return [
     'aim' => [
         'parent' => $parent,
+        'access' => 'admin',
         'position' => ['before' => '*'],
         'appearance' => [
             'dependsOnSubmodules' => true,


### PR DESCRIPTION
🔒 Add 'access' => 'admin' to the aim parent module entry 🛡️ Hide module from non-admin backend users (was visible because TYPO3 13 core does not honor appearance.dependsOnSubmodules)

fixes #17