### PR TITLE
[BUGFIX] Serialise tool schema per provider via Symfony AI

### DIFF
--- a/Classes/Provider/SymfonyAi/SymfonyAiPlatformAdapter.php
+++ b/Classes/Provider/SymfonyAi/SymfonyAiPlatformAdapter.php
@@ -23,8 +23,11 @@ use B13\Aim\Provider\AiProviderInterface;
 use B13\Aim\Request\ConversationRequest;
 use B13\Aim\Request\EmbeddingRequest;
 use B13\Aim\Request\Message\AbstractMessage;
+use B13\Aim\Request\Message\AssistantMessage;
+use B13\Aim\Request\Message\ToolMessage;
 use B13\Aim\Request\TextGenerationRequest;
 use B13\Aim\Request\ToolCallingRequest;
+use B13\Aim\Request\ToolResult;
 use B13\Aim\Request\TranslationRequest;
 use B13\Aim\Request\VisionRequest;
 use B13\Aim\Response\AiUsageStatistics;
@@ -38,6 +41,7 @@ use Symfony\AI\Platform\Message\Content\Image;
 use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\ProviderInterface;
+use Symfony\AI\Platform\Result\ToolCall as SymfonyToolCall;
 use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
 use Symfony\AI\Platform\Tool\ExecutionReference;
 use Symfony\AI\Platform\Tool\Tool as SymfonyTool;
@@ -187,7 +191,7 @@ class SymfonyAiPlatformAdapter implements
     public function processToolCallingRequest(ToolCallingRequest $request): ToolCallingResponse
     {
         $platform = $this->getPlatform($request->configuration);
-        $messages = $this->buildMessageBag($request->messages, $request->systemPrompt);
+        $messages = $this->buildMessageBag($request->messages, $request->systemPrompt, true, $request->toolResults);
 
         $tools = array_map(
             static fn($tool) => new SymfonyTool(
@@ -418,23 +422,76 @@ class SymfonyAiPlatformAdapter implements
     /**
      * Convert AiM messages to a Symfony AI MessageBag.
      *
+     * With $nativeToolProtocol enabled, assistant messages carrying tool calls
+     * and tool(-result) messages are mapped to Symfony AI's native message
+     * types, so each bridge serialises its provider-specific round-trip shape
+     * (tool_use/tool_result blocks on Anthropic, function_call/
+     * function_call_output items on the OpenAI Responses API, functionCall/
+     * functionResponse parts on Gemini, nested tool_calls/tool messages on the
+     * Chat Completions dialect).
+     *
+     * Native tool blocks are only valid when the request also defines tools —
+     * providers reject or blank a tool exchange without a tools option. Only
+     * processToolCallingRequest() enables this; requests without tools keep
+     * flattening tool messages to plain text turns.
+     *
+     * Providers require the assistant turn that requested a tool call to
+     * precede the corresponding result, so callers passing tool results must
+     * keep that assistant message (with its tool calls) in the history.
+     *
      * @param list<AbstractMessage> $aiMessages
+     * @param list<ToolResult> $toolResults
      */
-    private function buildMessageBag(array $aiMessages, string $systemPrompt): MessageBag
-    {
+    private function buildMessageBag(
+        array $aiMessages,
+        string $systemPrompt,
+        bool $nativeToolProtocol = false,
+        array $toolResults = [],
+    ): MessageBag {
         $messages = [];
         if ($systemPrompt !== '') {
             $messages[] = Message::forSystem($systemPrompt);
         }
+        // Tool calls seen in assistant turns, keyed by id, so tool results can
+        // reference the full call (Gemini needs the tool name in the response).
+        $seenToolCalls = [];
         foreach ($aiMessages as $msg) {
             $content = is_string($msg->content) ? $msg->content : '';
+            if ($nativeToolProtocol && $msg instanceof AssistantMessage && $msg->toolCalls !== []) {
+                $parts = $content !== '' ? [$content] : [];
+                foreach ($msg->toolCalls as $call) {
+                    $seenToolCalls[$call->id] = $this->toSymfonyToolCall($call);
+                    $parts[] = $seenToolCalls[$call->id];
+                }
+                $messages[] = Message::ofAssistant(...$parts);
+                continue;
+            }
+            if ($nativeToolProtocol && $msg instanceof ToolMessage) {
+                $messages[] = Message::ofToolCall(
+                    $seenToolCalls[$msg->toolCallId] ?? new SymfonyToolCall($msg->toolCallId, ''),
+                    $content,
+                );
+                continue;
+            }
             $messages[] = match ($msg->role) {
                 'system' => Message::forSystem($content),
                 'assistant' => Message::ofAssistant($content),
                 default => Message::ofUser($content),
             };
         }
+        foreach ($toolResults as $toolResult) {
+            $messages[] = Message::ofToolCall(
+                $seenToolCalls[$toolResult->toolCallId]
+                    ?? new SymfonyToolCall($toolResult->toolCallId, $toolResult->name),
+                $toolResult->output,
+            );
+        }
         return new MessageBag(...$messages);
+    }
+
+    private function toSymfonyToolCall(ToolCall $call): SymfonyToolCall
+    {
+        return new SymfonyToolCall($call->id, $call->name, $call->getDecodedArguments());
     }
 
     /**

--- a/Classes/Provider/SymfonyAi/SymfonyAiPlatformAdapter.php
+++ b/Classes/Provider/SymfonyAi/SymfonyAiPlatformAdapter.php
@@ -39,6 +39,8 @@ use Symfony\AI\Platform\Message\Message;
 use Symfony\AI\Platform\Message\MessageBag;
 use Symfony\AI\Platform\ProviderInterface;
 use Symfony\AI\Platform\TokenUsage\TokenUsageInterface;
+use Symfony\AI\Platform\Tool\ExecutionReference;
+use Symfony\AI\Platform\Tool\Tool as SymfonyTool;
 
 /**
  * Bridges any Symfony AI Platform bridge to AiM's provider system.
@@ -187,7 +189,15 @@ class SymfonyAiPlatformAdapter implements
         $platform = $this->getPlatform($request->configuration);
         $messages = $this->buildMessageBag($request->messages, $request->systemPrompt);
 
-        $tools = array_map(static fn($tool) => $tool->toArray(), $request->tools);
+        $tools = array_map(
+            static fn($tool) => new SymfonyTool(
+                new ExecutionReference($tool->name),
+                $tool->name,
+                $tool->description,
+                $tool->parameters ?: ['type' => 'object'],
+            ),
+            $request->tools,
+        );
 
         $options = $this->buildOptions($request->configuration->model, $request->maxTokens, $request->temperature, [
             'tools' => $tools,

--- a/Classes/Provider/SymfonyAi/SymfonyAiPlatformAdapter.php
+++ b/Classes/Provider/SymfonyAi/SymfonyAiPlatformAdapter.php
@@ -203,12 +203,23 @@ class SymfonyAiPlatformAdapter implements
             $request->tools,
         );
 
-        $options = $this->buildOptions($request->configuration->model, $request->maxTokens, $request->temperature, [
-            'tools' => $tools,
-        ]);
+        $extra = ['tools' => $tools];
+        if ($request->stream) {
+            $extra['stream'] = true;
+        }
+        $options = $this->buildOptions($request->configuration->model, $request->maxTokens, $request->temperature, $extra);
 
         try {
             $result = $platform->invoke($request->configuration->model, $messages, $options);
+
+            if ($request->stream) {
+                $streamIterator = new StreamChunkIterator(
+                    $result->asStream(),
+                    $request->configuration,
+                );
+                return new ToolCallingResponse('', streamIterator: $streamIterator);
+            }
+
             $usage = $this->extractUsage($result, $request->configuration);
             $rawResponse = $this->extractRawResponse($result);
             $content = $this->resolveTextContent($result);

--- a/Classes/Request/ToolCallingRequest.php
+++ b/Classes/Request/ToolCallingRequest.php
@@ -29,6 +29,8 @@ final class ToolCallingRequest implements AiRequestInterface
      * @param list<AbstractMessage> $messages Conversation messages
      * @param list<ToolDefinition> $tools Available tools the model may call
      * @param list<ToolResult> $toolResults Results from previously invoked tools (for multi-turn)
+     * @param bool $stream Stream the response; text chunks yield via the response's
+     *                     streamIterator, tool calls are collected on the iterator
      */
     public function __construct(
         public readonly ProviderConfiguration $configuration,
@@ -42,6 +44,7 @@ final class ToolCallingRequest implements AiRequestInterface
         public readonly string $user = '',
         public readonly array $metadata = [],
         public readonly ?PrivacyLevel $privacyLevelOverride = null,
+        public readonly bool $stream = false,
     ) {}
 
     public function getConfiguration(): ProviderConfiguration

--- a/Classes/Request/ToolDefinition.php
+++ b/Classes/Request/ToolDefinition.php
@@ -33,8 +33,20 @@ final class ToolDefinition
         public readonly bool $strict = false,
     ) {}
 
+    /**
+     * @deprecated since b13/aim 0.3.0, will be removed in 1.0.0. Tool definitions are
+     *             now serialized by Symfony AI's per-provider ToolNormalizer — pass
+     *             \Symfony\AI\Platform\Tool\Tool objects via $options['tools'] instead.
+     *             This method has no remaining callers inside the extension.
+     */
     public function toArray(): array
     {
+        trigger_error(
+            __METHOD__ . '() is deprecated and will be removed in b13/aim 1.0.0. Tool definitions are now '
+            . 'serialized by the Symfony AI bridge ToolNormalizers; pass \Symfony\AI\Platform\Tool\Tool objects instead.',
+            E_USER_DEPRECATED
+        );
+
         return [
             'type' => 'function',
             'function' => [

--- a/Classes/Response/StreamChunkIterator.php
+++ b/Classes/Response/StreamChunkIterator.php
@@ -13,13 +13,16 @@ declare(strict_types=1);
 namespace B13\Aim\Response;
 
 use B13\Aim\Domain\Model\ProviderConfiguration;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
 
 /**
  * Wraps a streaming generator and yields only text chunks.
  *
- * Non-text items (usage metadata, tool calls) are filtered out.
- * Accumulates the full response text and captures usage statistics
- * for deferred logging after the stream completes.
+ * Usage metadata is captured for deferred logging after the stream
+ * completes; tool-call deltas are collected and exposed via
+ * getToolCalls() once the stream is exhausted (they never yield as
+ * text). Accumulates the full response text.
  */
 class StreamChunkIterator implements \IteratorAggregate
 {
@@ -27,16 +30,33 @@ class StreamChunkIterator implements \IteratorAggregate
     private ?AiUsageStatistics $usage = null;
     private bool $exhausted = false;
 
+    /** @var list<ToolCall> */
+    private array $toolCalls = [];
+
     /**
      * @param \Generator $generator The streaming generator from the provider
      * @param ProviderConfiguration $configuration For cost calculation
      * @param \Closure|null $onComplete Called with (AiUsageStatistics, string $fullContent) when stream ends
+     * @param \Closure|null $onToolCallStart Called with (string $id, string $name) as soon as the
+     *                                       model starts emitting a tool call — arguments are not
+     *                                       known yet at that point
      */
     public function __construct(
         private readonly \Generator $generator,
         private readonly ProviderConfiguration $configuration,
         private readonly ?\Closure $onComplete = null,
+        private ?\Closure $onToolCallStart = null,
     ) {}
+
+    /**
+     * Attach the tool-call-start callback after construction — providers
+     * build this iterator internally, so consumers set the hook on the
+     * response's iterator before consuming the stream.
+     */
+    public function setOnToolCallStart(?\Closure $onToolCallStart): void
+    {
+        $this->onToolCallStart = $onToolCallStart;
+    }
 
     public function getIterator(): \Generator
     {
@@ -52,6 +72,24 @@ class StreamChunkIterator implements \IteratorAggregate
                     $text = (string)$chunk;
                     $this->accumulated .= $text;
                     yield $text;
+                    continue;
+                }
+                if ($chunk instanceof ToolCallStart) {
+                    if ($this->onToolCallStart !== null) {
+                        ($this->onToolCallStart)($chunk->getId(), $chunk->getName());
+                    }
+                    continue;
+                }
+                if ($chunk instanceof ToolCallComplete) {
+                    foreach ($chunk->getToolCalls() as $call) {
+                        $this->toolCalls[] = new ToolCall(
+                            $call->getId(),
+                            $call->getName(),
+                            $call->getArguments() === []
+                                ? '{}'
+                                : json_encode($call->getArguments(), JSON_THROW_ON_ERROR),
+                        );
+                    }
                     continue;
                 }
                 // Capture TokenUsage objects from the stream
@@ -76,6 +114,17 @@ class StreamChunkIterator implements \IteratorAggregate
     public function getAccumulatedContent(): string
     {
         return $this->accumulated;
+    }
+
+    /**
+     * Tool calls the model requested during the stream. Complete only
+     * once the stream is exhausted.
+     *
+     * @return list<ToolCall>
+     */
+    public function getToolCalls(): array
+    {
+        return $this->toolCalls;
     }
 
     public function getUsage(): AiUsageStatistics

--- a/Classes/Response/ToolCallingResponse.php
+++ b/Classes/Response/ToolCallingResponse.php
@@ -23,6 +23,9 @@ class ToolCallingResponse extends TextResponse
 {
     /**
      * @param list<ToolCall> $toolCalls
+     * @param StreamChunkIterator|null $streamIterator When streaming, text chunks yield
+     *        here and tool calls are available via $streamIterator->getToolCalls()
+     *        once the stream is exhausted
      */
     public function __construct(
         string $content,
@@ -30,20 +33,39 @@ class ToolCallingResponse extends TextResponse
         AiUsageStatistics $usage = new AiUsageStatistics(),
         array $rawResponse = [],
         array $errors = [],
+        public readonly ?StreamChunkIterator $streamIterator = null,
     ) {
         parent::__construct($content, $usage, $rawResponse, $errors);
     }
 
+    public function isStreaming(): bool
+    {
+        return $this->streamIterator !== null;
+    }
+
     /**
      * Whether the model requests tool execution before continuing.
+     * When streaming, only meaningful after the stream is exhausted.
      */
     public function requiresToolExecution(): bool
     {
-        return $this->toolCalls !== [];
+        return $this->getToolCalls() !== [];
+    }
+
+    /**
+     * @return list<ToolCall>
+     */
+    public function getToolCalls(): array
+    {
+        if ($this->streamIterator !== null) {
+            return $this->streamIterator->getToolCalls();
+        }
+        return $this->toolCalls;
     }
 
     public function isSuccessful(): bool
     {
-        return $this->errors === [] && ($this->content !== '' || $this->requiresToolExecution());
+        return $this->errors === []
+            && ($this->content !== '' || $this->requiresToolExecution() || $this->isStreaming());
     }
 }

--- a/Tests/Unit/Provider/SymfonyAi/SymfonyAiPlatformAdapterTest.php
+++ b/Tests/Unit/Provider/SymfonyAi/SymfonyAiPlatformAdapterTest.php
@@ -13,9 +13,17 @@ declare(strict_types=1);
 namespace B13\Aim\Tests\Unit\Provider\SymfonyAi;
 
 use B13\Aim\Provider\SymfonyAi\SymfonyAiPlatformAdapter;
+use B13\Aim\Request\Message\AssistantMessage;
+use B13\Aim\Request\Message\ToolMessage;
+use B13\Aim\Request\Message\UserMessage;
+use B13\Aim\Request\ToolResult;
+use B13\Aim\Response\ToolCall;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Message\AssistantMessage as SymfonyAssistantMessage;
+use Symfony\AI\Platform\Message\MessageBag;
+use Symfony\AI\Platform\Message\ToolCallMessage;
 
 final class SymfonyAiPlatformAdapterTest extends TestCase
 {
@@ -56,5 +64,100 @@ final class SymfonyAiPlatformAdapterTest extends TestCase
     public function resolveMaxTokensKeyMapsBridgeToCorrectOptionName(string $factoryClass, string $expectedKey): void
     {
         self::assertSame($expectedKey, SymfonyAiPlatformAdapter::resolveMaxTokensKey($factoryClass));
+    }
+
+    #[Test]
+    public function buildMessageBagMapsAssistantToolCallsToNativeSymfonyParts(): void
+    {
+        $bag = $this->buildMessageBag([
+            new UserMessage('What is the weather in Berlin?'),
+            new AssistantMessage('Let me check.', [
+                new ToolCall('call_1', 'get_weather', '{"city":"Berlin"}'),
+            ]),
+        ]);
+
+        $assistant = $bag->getMessages()[1];
+        self::assertInstanceOf(SymfonyAssistantMessage::class, $assistant);
+        self::assertTrue($assistant->hasToolCalls());
+        $toolCall = $assistant->getToolCalls()[0];
+        self::assertSame('call_1', $toolCall->getId());
+        self::assertSame('get_weather', $toolCall->getName());
+        self::assertSame(['city' => 'Berlin'], $toolCall->getArguments());
+    }
+
+    #[Test]
+    public function buildMessageBagMapsToolMessageToToolCallMessageWithResolvedName(): void
+    {
+        $bag = $this->buildMessageBag([
+            new UserMessage('What is the weather in Berlin?'),
+            new AssistantMessage('', [
+                new ToolCall('call_1', 'get_weather', '{"city":"Berlin"}'),
+            ]),
+            new ToolMessage('{"temperature":21}', 'call_1'),
+        ]);
+
+        $toolMessage = $bag->getMessages()[2];
+        self::assertInstanceOf(ToolCallMessage::class, $toolMessage);
+        self::assertSame('call_1', $toolMessage->getToolCall()->getId());
+        self::assertSame('get_weather', $toolMessage->getToolCall()->getName());
+        self::assertSame('{"temperature":21}', $toolMessage->getContent());
+    }
+
+    #[Test]
+    public function buildMessageBagAppendsToolResultsAsToolCallMessages(): void
+    {
+        $bag = $this->buildMessageBag(
+            [
+                new UserMessage('What is the weather in Berlin?'),
+                new AssistantMessage('', [
+                    new ToolCall('call_1', 'get_weather', '{"city":"Berlin"}'),
+                ]),
+            ],
+            [new ToolResult('call_1', 'get_weather', '{"temperature":21}')],
+        );
+
+        $messages = $bag->getMessages();
+        self::assertCount(3, $messages);
+        $toolMessage = $messages[2];
+        self::assertInstanceOf(ToolCallMessage::class, $toolMessage);
+        self::assertSame('call_1', $toolMessage->getToolCall()->getId());
+        self::assertSame('get_weather', $toolMessage->getToolCall()->getName());
+        self::assertSame('{"temperature":21}', $toolMessage->getContent());
+    }
+
+    #[Test]
+    public function buildMessageBagFlattensToolMessagesWithoutNativeToolProtocol(): void
+    {
+        // Requests without a tools option (conversation, text) must not emit
+        // native tool blocks — providers reject or blank a tool exchange when
+        // no tools are defined.
+        $bag = $this->buildMessageBag(
+            [
+                new UserMessage('What is the weather in Berlin?'),
+                new AssistantMessage('Let me check.', [
+                    new ToolCall('call_1', 'get_weather', '{"city":"Berlin"}'),
+                ]),
+                new ToolMessage('{"temperature":21}', 'call_1'),
+            ],
+            nativeToolProtocol: false,
+        );
+
+        $messages = $bag->getMessages();
+        $assistant = $messages[1];
+        self::assertInstanceOf(SymfonyAssistantMessage::class, $assistant);
+        self::assertFalse($assistant->hasToolCalls());
+        self::assertNotInstanceOf(ToolCallMessage::class, $messages[2]);
+    }
+
+    /**
+     * @param list<\B13\Aim\Request\Message\AbstractMessage> $messages
+     * @param list<ToolResult> $toolResults
+     */
+    private function buildMessageBag(array $messages, array $toolResults = [], bool $nativeToolProtocol = true): MessageBag
+    {
+        $adapter = new SymfonyAiPlatformAdapter('Symfony\\AI\\Platform\\Bridge\\Anthropic\\PlatformFactory');
+        $method = new \ReflectionMethod($adapter, 'buildMessageBag');
+
+        return $method->invoke($adapter, $messages, '', $nativeToolProtocol, $toolResults);
     }
 }

--- a/Tests/Unit/Response/StreamChunkIteratorTest.php
+++ b/Tests/Unit/Response/StreamChunkIteratorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TYPO3 CMS-based extension "aim" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+namespace B13\Aim\Tests\Unit\Response;
+
+use B13\Aim\Domain\Model\ProviderConfiguration;
+use B13\Aim\Response\StreamChunkIterator;
+use B13\Aim\Response\ToolCall;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\AI\Platform\Result\Stream\Delta\TextDelta;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallComplete;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolCallStart;
+use Symfony\AI\Platform\Result\Stream\Delta\ToolInputDelta;
+use Symfony\AI\Platform\Result\ToolCall as SymfonyToolCall;
+
+final class StreamChunkIteratorTest extends TestCase
+{
+    #[Test]
+    public function yieldsOnlyTextAndCollectsToolCalls(): void
+    {
+        $iterator = new StreamChunkIterator(
+            (function (): \Generator {
+                yield new TextDelta('Let me check. ');
+                yield new ToolCallStart('call_1', 'get_weather');
+                yield new ToolInputDelta('call_1', 'get_weather', '{"city":');
+                yield new ToolInputDelta('call_1', 'get_weather', '"Berlin"}');
+                yield new ToolCallComplete([
+                    new SymfonyToolCall('call_1', 'get_weather', ['city' => 'Berlin']),
+                ]);
+            })(),
+            new ProviderConfiguration(['uid' => 1, 'ai_provider' => 'test']),
+        );
+
+        $chunks = iterator_to_array($iterator, false);
+
+        self::assertSame(['Let me check. '], $chunks);
+        self::assertSame('Let me check. ', $iterator->getAccumulatedContent());
+        self::assertCount(1, $iterator->getToolCalls());
+        $toolCall = $iterator->getToolCalls()[0];
+        self::assertInstanceOf(ToolCall::class, $toolCall);
+        self::assertSame('call_1', $toolCall->id);
+        self::assertSame('get_weather', $toolCall->name);
+        self::assertSame(['city' => 'Berlin'], $toolCall->getDecodedArguments());
+    }
+
+    #[Test]
+    public function invokesOnToolCallStartBeforeArgumentsAreComplete(): void
+    {
+        $started = [];
+        $iterator = new StreamChunkIterator(
+            (function (): \Generator {
+                yield new ToolCallStart('call_1', 'get_weather');
+                yield new ToolCallComplete([
+                    new SymfonyToolCall('call_1', 'get_weather', []),
+                ]);
+            })(),
+            new ProviderConfiguration(['uid' => 1, 'ai_provider' => 'test']),
+            null,
+            static function (string $id, string $name) use (&$started): void {
+                $started[] = [$id, $name];
+            },
+        );
+
+        iterator_to_array($iterator, false);
+
+        self::assertSame([['call_1', 'get_weather']], $started);
+        self::assertSame('{}', $iterator->getToolCalls()[0]->arguments);
+    }
+
+    #[Test]
+    public function plainTextStreamStillYieldsStringsAndHasNoToolCalls(): void
+    {
+        $iterator = new StreamChunkIterator(
+            (function (): \Generator {
+                yield 'Hello ';
+                yield new TextDelta('world');
+            })(),
+            new ProviderConfiguration(['uid' => 1, 'ai_provider' => 'test']),
+        );
+
+        self::assertSame(['Hello ', 'world'], iterator_to_array($iterator, false));
+        self::assertSame([], $iterator->getToolCalls());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,14 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^11.0",
-		"typo3/testing-framework": "^9.0"
+		"typo3/testing-framework": "^9.0",
+		"symfony/ai-platform": "^0.9"
 	},
 	"conflict": {
-		"symfony/ai-platform": "<0.8"
+		"symfony/ai-platform": "<0.9"
 	},
 	"suggest": {
-		"symfony/ai-platform": "^0.8 — required to use Symfony AI bridges as providers (OpenAI, Anthropic, Gemini, Mistral, Ollama, etc.)",
+		"symfony/ai-platform": "^0.9 — required to use Symfony AI bridges as providers (OpenAI, Anthropic, Gemini, Mistral, Ollama, etc.)",
 		"typo3/cms-dashboard": "Enables dashboard widgets for AI usage analytics"
 	},
 	"autoload": {


### PR DESCRIPTION
processToolCallingRequest() passed ToolDefinition::toArray() arrays into $options['tools'], bypassing Symfony AI's per-bridge ToolNormalizers. The single nested shape 400s on the OpenAI Responses API and is wrong for Anthropic and Gemini. Pass native Symfony Tool objects so each bridge serialises its own shape; deprecate the now-unused toArray().

Resolves: #20